### PR TITLE
V1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
 .DS_Store
 node_modules
-dist
-
-# local env files
-.env
-.env.local
-.env.*.local
+lib
 
 # Log files
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "textlint-rule-a3rt-proofreading-v2",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "lib/textlint-rule-a3rt-proofreading-v2.js",
   "description": "textlint rule to check Japanese with A3RT Proofreading API",
   "repository": "https://github.com/shivase/textlint-rule-a3rt-proofreading-v2",
+  "bugs": "https://github.com/shivase/textlint-rule-a3rt-proofreading-v2/issues",
+  "homepage": "https://github.com/shivase/textlint-rule-a3rt-proofreading-v2",
   "author": "shivase",
   "license": "MIT",
   "keywords": [
@@ -11,8 +13,20 @@
     "textlintrule",
     "a3rt"
   ],
-  "bugs": "https://github.com/shivase/textlint-rule-a3rt-proofreading-v2/issues",
-  "homepage": "https://github.com/shivase/textlint-rule-a3rt-proofreading-v2",
+  "scripts": {
+    "prepare": "husky install",
+    "prebuild": "rimraf lib",
+    "build": "NO_INLINE=true textlint-scripts build",
+    "lint": "run-s lint:*",
+    "lint:eslint": "eslint . --ext .ts --fix",
+    "lint:prettier": "prettier --write .",
+    "test": "NO_INLINE=true textlint-scripts test",
+    "prepublish": "yarn build"
+  },
+  "dependencies": {
+    "axios": "^1.1.2",
+    "js-yaml": "^4.1.0"
+  },
   "devDependencies": {
     "@types/chai": "^4.3.3",
     "@types/chai-as-promised": "^7.1.5",
@@ -21,7 +35,6 @@
     "@types/node": "^18.8.4",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
-    "axios": "^1.1.2",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",
     "create-textlint-rule": "^1.5.0",
@@ -31,9 +44,7 @@
     "eslint-import-resolver-typescript": "^3.5.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "fs": "^0.0.1-security",
     "husky": "^8.0.1",
-    "js-yaml": "^4.1.0",
     "lint-staged": "^13.0.3",
     "mocha": "^10.0.0",
     "msw": "^0.47.4",
@@ -45,16 +56,6 @@
     "textlint-tester": "^12.2.2",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
-  },
-  "scripts": {
-    "prepare": "husky install",
-    "prebuild": "rimraf lib",
-    "build": "textlint-scripts build",
-    "lint": "run-s lint:*",
-    "lint:eslint": "eslint . --ext .ts --fix",
-    "lint:prettier": "prettier --write .",
-    "test": "mocha --require textlint-scripts/register-ts \"test/**/*.ts\"",
-    "prepublish": "npm run --if-present build"
   },
   "files": [
     "lib/",
@@ -68,6 +69,5 @@
       "prettier --write --loglevel=error",
       "eslint --fix"
     ]
-  },
-  "dependencies": {}
+  }
 }

--- a/test/textlintrc.test.ts
+++ b/test/textlintrc.test.ts
@@ -2,11 +2,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import path from 'path';
 import { use, expect } from 'chai';
-import chaiAsPromised = require('chai-as-promised');
-
-// import { TextLintEngine, TextLintCore } from 'textlint';
+import chaiAsPromised from 'chai-as-promised';
 import { TextLintEngine } from 'textlint';
-// import rule from '../src/textlint-rule-a3rt-proofreading-v2';
 import { server } from './mocks/server';
 
 use(chaiAsPromised);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,11 +2900,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-  integrity sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==
-
 fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"


### PR DESCRIPTION
testlint-scriptsを通すと、内部でstatic-fsが走ってしまい、fs読み込みの部分で正常にファイル読み込みができなくなる問題を修正。

ブラウザ対応のためにstatic-fsは入っていると思うので、これで悪さをする可能性がある